### PR TITLE
Update follow_up.rb

### DIFF
--- a/lib/follow_up.rb
+++ b/lib/follow_up.rb
@@ -6,7 +6,7 @@ module FollowUp
       value.value = nil
       value.save
       issue.priority = priority
-      issue.assigned_to = last_user_for(issue)
+      issue.assigned_to ||= last_user_for(issue)
       issue.save
     end
   end


### PR DESCRIPTION
"Zugewiesen an" wird beim Wiedervorlegen nur gesetzt, falls es leer ist